### PR TITLE
Add Ruby New Zealand Incorporated

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,7 @@ http://queueup.gg/
 ### PyContribs
 Group of open-source Python package maintainers.
 https://github.com/pycontribs/
+
+### Ruby New Zealand Incorporated
+Ruby New Zealand fosters and supports the Ruby programming language, its users and community in New Zealand. It assists with community events such as local meetups, Rails Camps and Rails Girls, and helps ensure these are safe and welcoming spaces.
+https://ruby.nz/


### PR DESCRIPTION
## Your project

**1Password Teams url**: rubynz.1password.com

**Project name**:  Ruby New Zealand Incorporated

**Short description**: Ruby New Zealand fosters and supports the Ruby programming language, its users and community in New Zealand. It assists with community events such as local meetups, Rails Camps and Rails Girls, and helps ensure these are safe and welcoming spaces.

**Project age**: 4 years

**Number of core contributors**: 6-7 committee members (re-elected yearly)

**Project website**: https://ruby.nz/

**Repository url**: https://github.com/rubynz

**Latest release url**: Most recent event: https://kiwi.ruby.nz/

**License type**: MIT

**License url**: https://github.com/rubynz/conf/blob/master/LICENSE.md


## Tell us about yourself

**Name**: Steve Hoeksema

**Email**: treasurer@ruby.nz

**Project role**: Treasurer

**Website**: https://github.com/steveh , https://ruby.nz/#current-committee
